### PR TITLE
[feat] 왼쪽 사이드바 내 캘린더 UI 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -227,12 +227,19 @@ select:-webkit-autofill:hover,
 select:-webkit-autofill:focus {
   -webkit-text-fill-color: #fff;
 }
-
+:root {
+  --fc-border-color:white;
+}
 /* Calendar CSS */
+.fc {
+  border:none !important;
+}
 .fc-day-sun a { /* 일요일 컬러 */
   color: red !important;
 }
-
+#calendar-container {
+  border:none !important;
+}
 .fc-day-sat a { /* 토요일 컬러 */
   color: blue !important;
 }
@@ -242,11 +249,27 @@ select:-webkit-autofill:focus {
   margin-bottom: 3px !important;
   padding-left: 2px;
 }
-/* 
-.fc .fc-daygrid-day-frame {
-  width: 150px !important;
-  height: 150px !important;
-} */
+
+ /* FullCalendar 날짜 셀 테두리 제거 */
+  .fc-daygrid-day {
+  border: none !important;
+}
+
+/* FullCalendar 전체 달력 테두리 제거 */
+.fc-scrollgrid {
+  border: none !important;
+}
+
+/* 이벤트의 테두리 제거 */
+.fc-event {
+  border: none !important;
+}
+
+/* 날짜 헤더 (일, 월, 화 ...)의 테두리 제거 */
+.fc-col-header-cell {
+  border: none !important;
+}
+
 
 .fc-toolbar {
   display: flex;
@@ -305,4 +328,11 @@ select:-webkit-autofill:focus {
   box-shadow: none !important;
 }
 
+/* CalendarOne 스타일 */
+.calendar-small-style .fc-daygrid-day {
+  border:none !important;
+}
 
+.calendar-small-style .fc-toolbar-title {
+  color: #0000ff;
+}

--- a/src/app/main/calendar/page.tsx
+++ b/src/app/main/calendar/page.tsx
@@ -6,7 +6,6 @@ const calendarPage = () => {
   return (
     <div>
       <Calendar />
-
     </div>
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,11 @@
 import MainLayout from "./main/page";
 
 const Home = () => {
+
   return (
-    <MainLayout />
+    <>
+      <MainLayout />
+    </> 
   )
 };
 

--- a/src/components/LeftSideBar.tsx
+++ b/src/components/LeftSideBar.tsx
@@ -1,5 +1,7 @@
+import FullCalendar from '@fullcalendar/react';
 import React from 'react';
-import { BsChevronDoubleRight } from "react-icons/bs";
+import dayGridPlugin from '@fullcalendar/daygrid';
+import koLocale from '@fullcalendar/core/locales/ko';
 
 interface LeftSidebarProps {
   isOpen: boolean;
@@ -10,7 +12,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({ isOpen, toggleSidebar }) => {
   return (
     <div
       className={`fixed top-0 left-0 h-full bg-white shadow-lg z-40 transition-transform duration-300 transform ${
-        isOpen ? 'translate-x-0' : '-translate-x-[calc(100%-4rem)]'
+        isOpen ? 'translate-x-0' : '-translate-x-[calc(100%-3rem)]'
       } w-80 flex flex-col`}  style={{top: '4.5rem'}} // 사이드바와 달력을 함께 움직이도록 설정
     >
       {/* 사이드바 아이콘 부분 */}
@@ -18,19 +20,42 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({ isOpen, toggleSidebar }) => {
         <img
           src="/assets/ICON.png"
           onClick={toggleSidebar}
-          className="w-7 h-7 cursor-pointer mr-4"
+          className="w-5 h-5 cursor-pointer mr-2 mt-2"
           alt="아이콘"
+
         />
       </div>
       
 
       {/* 사이드바 내용 부분 */}
-      <div className="w-[calc(100%-4rem)] h-full bg-white p-6 flex flex-col">
-        <h2 className="text-lg font-bold mb-4">Calendar📅</h2>
+      <div className="w-[calc(100%-2rem)] h-full bg-white p-3 flex flex-col ml-2">
 
         {/* 달력 부분 추가 예정*/}
+        <div className=''>
+          <FullCalendar
+          plugins={[ dayGridPlugin ]}
+          initialView="dayGridMonth"
+          locale={koLocale}
+          dayHeaders={false}
+          headerToolbar={{
+            left: 'title prev,next',
+            center: '',
+            right: ''
+          }}
+          height={450} // 달력의 높이를 고정
+          contentHeight={100} // 내용 영역의 높이 설정
+          aspectRatio={1} // 넓이와 높이 비율 설정
 
-
+          events={[
+            { title: 'Event 1', date: '2024-06-01' },
+            { title: 'Event 2', date: '2024-06-07' }
+          ]}
+          dayCellContent={(dayCellArg) => (
+            <span>{dayCellArg.date.getDate()}</span>  // 날짜 숫자만 표시
+          )}
+          viewClassNames="calendar-small-style"
+        />
+      </div>
         {/* 예약 리스트 부분 */}
         <div className="flex-grow">
           <h3 className="text-md font-bold mb-4 text-gray-500">나의 플레이스 리스트🌲</h3>


### PR DESCRIPTION
<img width="1262" alt="스크린샷 2024-10-15 오후 7 55 39" src="https://github.com/user-attachments/assets/bd5cae87-f773-4d1f-ae34-588afe7d88c0">
- 왼쪽 사이드바 내에 메인 화면과 같은 달력을 리사이징 하여 추가하였습니다.