### PR TITLE
[feat] 플랫폼 계정 정보 저장 React Query 구현

### DIFF
--- a/src/app/hooks/account/useSaveAccountQuery.tsx
+++ b/src/app/hooks/account/useSaveAccountQuery.tsx
@@ -1,0 +1,39 @@
+import { axiosAccess } from "../../api/axiosInstance";
+import { useMutation } from "@tanstack/react-query";
+import { useToast } from "../useToast";
+
+interface SaveAccountParams {
+  platform: string;
+  email: string;
+  password: string;
+}
+
+// API 응답 타입 정의
+interface SaveAccountResponse {
+  success: boolean;
+  message: string;
+}
+
+const fetchAPI = async ({ platform, email, password }: SaveAccountParams) => {
+  const response = await axiosAccess.post("/platform", {
+    platform,
+    email,
+    password,
+  });
+  return response.data as SaveAccountResponse;
+};
+
+const useSaveAccountQuery = () => {
+  const { toastSuccess, toastError } = useToast();
+  return useMutation({
+    mutationFn: fetchAPI,
+    onSuccess: () => {
+      toastSuccess("계정 저장에 성공하였습니다!");
+    },
+    onError: () => {
+      toastError("계정 저장에 실패하였습니다.");
+    },
+  });
+};
+
+export default useSaveAccountQuery;


### PR DESCRIPTION
* useSaveAccountQuery 구현 
* 사용자가 입력한 플랫폼(아워스페이스, 스페이스 클라우드) 이메일, 비밀번호를 서버에 보내 DB에 저장하는 Query 구현