### PR TITLE
[Feat] Google Analytics 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ yarn-error.log*
 # local env files
 .env*.local
 .env
+.env.local
 
 # vercel
 .vercel

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fullcalendar/daygrid": "^6.1.15",
         "@fullcalendar/react": "^6.1.15",
+        "@next/third-parties": "^14.2.15",
         "@tanstack/react-query": "^5.59.15",
         "@types/fullcalendar": "^3.8.0",
         "axios": "^1.7.7",
@@ -3011,6 +3012,18 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-14.2.15.tgz",
+      "integrity": "sha512-15CvipE1p1GtlzVfbDfXPrAGIhzJJe75Yy6+GIBRTd36lu95BegRsUJwCxJYoKz47Q09stcU2gJDMduMGqrikw==",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0",
+        "react": "^18.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -14081,6 +14094,11 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA=="
     },
     "node_modules/timers-browserify": {
       "version": "2.0.12",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@fullcalendar/daygrid": "^6.1.15",
     "@fullcalendar/react": "^6.1.15",
+    "@next/third-parties": "^14.2.15",
     "@tanstack/react-query": "^5.59.15",
     "@types/fullcalendar": "^3.8.0",
     "axios": "^1.7.7",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import Header from "@/components/Header";
 import "./globals.css";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import { GoogleAnalytics, GoogleTagManager } from "@next/third-parties/google";
 
 interface RootLayoutProps {
   children: React.ReactNode;
@@ -32,6 +33,11 @@ export default function RootLayout({ children }: RootLayoutProps) {
           />
         </main>
       </body>
+      {process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_GA_ID && (
+        <GoogleAnalytics
+          gaId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_GA_ID}
+        />
+      )}
     </html>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/app/hooks/account/useSaveAccountQuery.txs"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# 구현 내용
화면 체류 시간 측정을 위한 Google Analytics 세팅

3rd party 사용시 사용했던 설치 명령어
```
 npm install @next/third-parties@latest
```

### 참고사항
1. 버튼 액션에 대한 데이터 수집은 백엔드에서 버튼 클릭시 호출되는 API에서 하기로 결정
2. Tag Manager와 Google Analytics 에서 GA만 사용하기로 결정
3. 화면별 체류 시간은 별도의 태그를 심지 않아도 가능
4. .env.local에 GA 아이디는 따로 전달 완료
5. Vercel > Setting > Environment Variables에서 GA ID 추가 필요(key, value)
    key: `NEXT_PUBLIC_GOOGLE_ANALYTICS_GA_ID`
    value: G-
### 레퍼런스
[Using Google Analytics with Next.js (through `next/script`)](https://nextjs.org/docs/messages/next-script-for-ga)
[Next.js 14(app router)에서 GA4, GTM, @next/third-parties 사용하기](https://velog.io/@clydehan/Next.js-14app-router%EC%97%90%EC%84%9C-GA4-GTM-nextthird-parties-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0)